### PR TITLE
fix: resolve all GitHub Actions build errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,8 @@ gem 'github-pages', '232', group: :jekyll_plugins
 # Required for Ruby 3.x compatibility with Jekyll 3.x
 gem 'webrick', '~> 1.8'
 
+# Required for jekyll-github-metadata with Faraday v2.0+
+gem 'faraday-retry'
+
 # jekyll-octicons has no stable RubyGems release; excluded from local dev.
 # GitHub Pages handles it server-side via the github-pages gem.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,8 @@ GEM
       logger
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-aarch64-linux-musl)
     ffi (1.17.4-arm-linux-gnu)
@@ -307,6 +309,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  faraday-retry
   github-pages (= 232)
   webrick (~> 1.8)
 
@@ -331,6 +334,7 @@ CHECKSUMS
   execjs (2.10.1) sha256=abe0ae028467eb8e30c10814eb934d07876a691aae7e803d813b7ce5a75e73f1
   faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
+  faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   ffi (1.17.4-aarch64-linux-gnu) sha256=b208f06f91ffd8f5e1193da3cae3d2ccfc27fc36fba577baf698d26d91c080df
   ffi (1.17.4-aarch64-linux-musl) sha256=9286b7a615f2676245283aef0a0a3b475ae3aae2bb5448baace630bb77b91f39
   ffi (1.17.4-arm-linux-gnu) sha256=d6dbddf7cb77bf955411af5f187a65b8cd378cb003c15c05697f5feee1cb1564

--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,6 @@
 name: Aravind Kumar, DonOfDen
+title: Aravind Kumar G | DonOfDen
+repository: donofden/donofden.github.io
 markdown: kramdown
 permalink: /blog/:year/:month/:day/:title
 style: light

--- a/_posts/2020-05-25-CI-CD-with-GitHub-Actions-with-poetry.md
+++ b/_posts/2020-05-25-CI-CD-with-GitHub-Actions-with-poetry.md
@@ -150,6 +150,7 @@ Now, to use `GitHub Actions`, we need to create workflows that are going to be e
 
 `pullrequestchecks.yml` will contain a jobs which will be triggered on every push to the repository, let's look at it:
 
+{% raw %}
 ```yaml
 # Checks that we can build and validate the Unittest
 name: Pull-Request-Checks
@@ -184,6 +185,7 @@ jobs:
           restore-keys: |
             poetry-${{ hashFiles('**/poetry.lock') }}
 ```
+{% endraw %}
 
 The job runs it though, it first checks out our repository by executing action called `checkout` which is published on GitHub. 
 
@@ -214,6 +216,7 @@ Installing `poetry` and running `pytest` are straing forward.
 
 Complete `pullrequestchecks.yml` file.
 
+{% raw %}
 ```yaml
 # Checks that we can build and validate the Unittest
 name: Pull-Request-Checks
@@ -262,6 +265,7 @@ jobs:
       - name: Generate XML Report
         run: PYTHONPATH=src/ poetry run python -m coverage xml
 ```
+{% endraw %}
 
 That's it! We have created a GitHub action, Once u pushed this code to your repo. When ever a `Pull Request` is created for the repo, A `Github` action will be triggered and which will run `pytest` against the `checkout` branch and submit the report. We then can verify the test output and `coverage` during PR review.
 


### PR DESCRIPTION
- Add repository: donofden/donofden.github.io to _config.yml (fixes 'No repo name found' error in CI — _config_dev.yml is gitignored)
- Add title: key to _config.yml (fixes site.name/site.title inconsistency warning from jekyll-github-metadata)
- Add faraday-retry gem to Gemfile (fixes 'install faraday-retry gem' warning from Faraday v2.0+)
- Wrap both GitHub Actions code blocks in poetry blog post with raw/endraw (fixes Liquid syntax error on hashFiles() expressions in code blocks)